### PR TITLE
Merge transfer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ fn account(&self, _: PublicKey) -> AccountData;
 fn allowance(&self, _: Allowance) -> u64;
 fn transfer(&mut self, _: Transfer);
 fn transfer_from(&mut self, _: TransferFrom);
-fn transfer_from_contract(&mut self, _: TransferFromContract);
 fn approve(&mut self, _: Approve);
 ```
 

--- a/tests/contract/src/lib.rs
+++ b/tests/contract/src/lib.rs
@@ -33,17 +33,13 @@ static mut STATE: TokenState = TokenState {
 };
 
 impl TokenState {
-    fn token_send(&mut self, transfer: TransferFromContract) {
-        if let Err(err) =
-            abi::call::<_, ()>(self.token_contract, "transfer_from_contract", &transfer)
-        {
+    fn token_send(&mut self, transfer: Transfer) {
+        if let Err(err) = abi::call::<_, ()>(self.token_contract, "transfer", &transfer) {
             panic!("Failed sending tokens: {err}");
         }
 
-        if transfer.sender.is_none()
-            || matches!(transfer.sender, Some(Account::Contract(x)) if x == self.this_contract)
-        {
-            self.balance -= transfer.value;
+        if matches!(transfer.sender(), Account::Contract(x) if *x == self.this_contract) {
+            self.balance -= transfer.value();
         }
     }
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -327,7 +327,7 @@ fn approve() {
         "The account should not be allowed to spend tokens from the deployed account"
     );
 
-    let approve = Approve::new(&session.deploy_sk, pk, APPROVED_AMOUNT, 1);
+    let approve = Approve::new_external(&session.deploy_sk, pk, APPROVED_AMOUNT, 1);
     session
         .call_token::<_, ()>("approve", &approve)
         .expect("Approving should succeed");
@@ -366,7 +366,7 @@ fn transfer_from() {
         "The account should not be allowed to spend tokens from the deployed account"
     );
 
-    let approve = Approve::new(&session.deploy_sk, pk, APPROVED_AMOUNT, 1);
+    let approve = Approve::new_external(&session.deploy_sk, pk, APPROVED_AMOUNT, 1);
     session
         .call_token::<_, ()>("approve", &approve)
         .expect("Approving should succeed");
@@ -377,7 +377,8 @@ fn transfer_from() {
         "The account should be allowed to spend tokens from the deployed account"
     );
 
-    let transfer_from = TransferFrom::new(&sk, session.deploy_pk(), pk, TRANSFERRED_AMOUNT, 1);
+    let transfer_from =
+        TransferFrom::new_external(&sk, session.deploy_pk(), pk, TRANSFERRED_AMOUNT, 1);
     session
         .call_token::<_, ()>("transfer_from", &transfer_from)
         .expect("Transferring from should succeed");

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -290,11 +290,15 @@ fn transfer_from_contract() {
         "The contract to transfer to should have its initial balance"
     );
 
-    let transfer = TransferFromContract {
-        receiver: Account::External(session.deploy_pk()),
-        sender: None,
-        value: TRANSFERRED_AMOUNT,
-    };
+    let sender = Account::Contract(HOLDER_ID);
+
+    let transfer = Transfer::new_contract(
+        sender,
+        Account::External(session.deploy_pk()),
+        TRANSFERRED_AMOUNT,
+        0,
+    );
+
     session
         .call_holder::<_, ()>("token_send", &transfer)
         .expect("Transferring should succeed");

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -210,7 +210,7 @@ fn transfer() {
         "The account to transfer to should have no balance"
     );
 
-    let transfer = Transfer::new(
+    let transfer = Transfer::new_external(
         &session.deploy_sk,
         session.deploy_pk,
         pk,
@@ -250,7 +250,7 @@ fn transfer_to_contract() {
         "The contract to transfer to should have its initial balance"
     );
 
-    let transfer = Transfer::new(
+    let transfer = Transfer::new_external(
         &session.deploy_sk,
         session.deploy_pk,
         HOLDER_ID,
@@ -606,7 +606,7 @@ fn test_pause() {
         "The account to transfer to should have no balance"
     );
 
-    let transfer = Transfer::new(&session.deploy_sk, session.deploy_pk, pk, VALUE, 1);
+    let transfer = Transfer::new_external(&session.deploy_sk, session.deploy_pk, pk, VALUE, 1);
     let receipt = session.call_token::<_, ()>("transfer", &transfer);
 
     match receipt.err() {
@@ -646,7 +646,7 @@ fn test_force_transfer() {
     let sk = SecretKey::random(&mut rng);
     let pk = PublicKey::from(&sk);
 
-    let transfer = Transfer::new(&session.deploy_sk, session.deploy_pk, pk, VALUE, 1);
+    let transfer = Transfer::new_external(&session.deploy_sk, session.deploy_pk, pk, VALUE, 1);
     session
         .call_token::<_, ()>("transfer", &transfer)
         .expect("Transferring should succeed");
@@ -662,13 +662,13 @@ fn test_force_transfer() {
         "The account transferred to should have the transferred amount"
     );
 
-    let force_transfer = Transfer::new(&session.owner_sk, pk, session.owner, VALUE, 1);
+    let force_transfer = Transfer::new_external(&session.owner_sk, pk, session.owner, VALUE, 1);
 
     session
         .call_token::<_, ()>("force_transfer", &force_transfer)
         .expect("Force transferring should succeed");
 
-    let force_transfer = Transfer::new(&session.owner_sk, pk, session.owner, VALUE, 2);
+    let force_transfer = Transfer::new_external(&session.owner_sk, pk, session.owner, VALUE, 2);
 
     match session
         .call_token::<_, ()>("force_transfer", &force_transfer)
@@ -696,7 +696,7 @@ fn test_sanctions() {
     let test_pk = PublicKey::from(&test_sk); // not blocked, not frozen
 
     // Transfer VALUE to test account
-    let transfer = Transfer::new(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 1);
+    let transfer = Transfer::new_external(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 1);
     session
         .call_token::<_, ()>("transfer", &transfer)
         .expect("Transferring should succeed");
@@ -727,7 +727,7 @@ fn test_sanctions() {
     }
 
     // Transfer VALUE to test account
-    let transfer = Transfer::new(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 2);
+    let transfer = Transfer::new_external(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 2);
     match session.call_token::<_, ()>("transfer", &transfer).err() {
         Some(VMError::Panic(panic_msg)) => {
             assert_eq!(panic_msg, BLOCKED);
@@ -738,7 +738,7 @@ fn test_sanctions() {
     }
 
     // Transfer VALUE from test account
-    let transfer = Transfer::new(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
+    let transfer = Transfer::new_external(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
     match session.call_token::<_, ()>("transfer", &transfer).err() {
         Some(VMError::Panic(panic_msg)) => {
             assert_eq!(panic_msg, BLOCKED);
@@ -763,13 +763,13 @@ fn test_sanctions() {
     );
 
     // Transfer VALUE to test account
-    let transfer = Transfer::new(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 2);
+    let transfer = Transfer::new_external(&session.deploy_sk, session.deploy_pk, test_pk, VALUE, 2);
     session
         .call_token::<_, ()>("transfer", &transfer)
         .expect("Transfer to frozen account should succeed");
 
     // Transfer VALUE from test account
-    let transfer = Transfer::new(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
+    let transfer = Transfer::new_external(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
     match session.call_token::<_, ()>("transfer", &transfer).err() {
         Some(VMError::Panic(panic_msg)) => {
             assert_eq!(panic_msg, FROZEN);
@@ -797,7 +797,7 @@ fn test_sanctions() {
         .expect("Unfreezing should succeed");
 
     // Transfer VALUE from test account
-    let transfer = Transfer::new(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
+    let transfer = Transfer::new_external(&test_sk, test_pk, session.deploy_pk(), VALUE, 1);
     session
         .call_token::<_, ()>("transfer", &transfer)
         .expect("Transfer should succeed again");

--- a/types/src/token.rs
+++ b/types/src/token.rs
@@ -247,22 +247,6 @@ impl TransferFrom {
     }
 }
 
-/// Data used to approve spending tokens from a contract's account.
-///
-/// Note that there is no need for a signature, since contracts are essentially
-/// asserting via their code that they wish the transaction to be made.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize)]
-#[archive_attr(derive(CheckBytes))]
-pub struct TransferFromContract {
-    /// The account to transfer to.
-    pub receiver: Account,
-    /// The owner of the funds to transfer from. If `None` it will be assumed
-    /// to be the contract itself.
-    pub sender: Option<Account>,
-    /// The value to transfer.
-    pub value: u64,
-}
-
 /// Data used to approve spending tokens from a user's account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]

--- a/types/src/token/account.rs
+++ b/types/src/token/account.rs
@@ -20,6 +20,9 @@ pub const BALANCE_TOO_LOW: &str = "The account doesn't have enough tokens";
 /// Error message for when the account is not found in the contract.
 pub const ACCOUNT_NOT_FOUND: &str = "The account does not exist";
 
+/// Error message for when a wrong contract calls the contract.
+pub const INVALID_CALLER: &str = "Invalid caller";
+
 /// The label for an account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]


### PR DESCRIPTION
This PR removes the transfer_from_contract function in favour of allowing a contract to also use the transfer function.