### PR TITLE
governance: Add governance contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
 	"core",
 	"token",
+	"governance",
 	"tests",
 	"tests/holder"
 ]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+// The error messages given by the governance-contract.
+
+/// Error message given when the state is about to be updated to an empty set of
+/// owners.
+pub const EMPTY_OWNER: &str = "The owner-set must not be empty";
+
+/// Error message given when the state is about to be updated to a set of owners
+/// that is larger than `u8::MAX`.
+pub const TOO_MANY_OWNERS: &str = "The owner-set cannot be larger than u8::MAX";
+
+/// Error message given when the state is about to be updated to a set of
+/// operators that is larger than `u8::MAX`.
+pub const TOO_MANY_OPERATORS: &str =
+    "The operator-set cannot be larger than u8::MAX";
+
+/// Error message given when the contract has already been initialized and init
+/// is called.
+pub const ALLREADY_INITIALIZED: &str =
+    "The contract has already been initialized";
+
+/// Error message given when a given token-contract call is not registered.
+pub const TOKEN_CALL_NOT_FOUND: &str =
+    "The given token-contract call is not registered";
+
+/// Error message given when there are duplicate owner-keys.
+pub const DUPLICATE_OWNER: &str = "Duplicate owner-key found";
+
+/// Error message given when there are duplicate operator-keys.
+pub const DUPLICATE_OPERATOR: &str = "Duplicate operator-key found";
+
+/// Error message given when there are duplicate signer-keys.
+pub const DUPLICATE_SIGNER: &str = "Duplicate signer-key found";
+
+/// Error message given when one of the signer indices doesn't exist.
+pub const SIGNER_NOT_FOUND: &str = "The given signer doesn't exist";
+
+/// Error message given in case of an invalid signature.
+pub const INVALID_SIGNATURE: &str = "The signature is invalid";
+
+/// Error message given when the signature threshold for calling a function on
+/// the token-contract is not met.
+pub const THRESHOLD_NOT_MET: &str =
+    "The required threshold of signatures has not been met";
+
+/// Error given when the threshold is 0 at the signature authorization.
+pub const THRESHOLD_ZERO: &str =
+    "The threshold shouldn't be 0 at authorization";
+
+/// Error message given when an operator tries to trigger an inter-contract call
+/// that only the owners can authorize.
+pub const UNAUTHORIZED_TOKEN_CALL: &str =
+    "This inter-contract call need owners authorization";
+
+/// Error message given when an operator token-contract call panics
+pub const OPERATOR_TOKEN_CALL_PANIC: &str =
+    "Calling the specified operator function on the token-contract should succeed";

--- a/core/src/governance.rs
+++ b/core/src/governance.rs
@@ -9,6 +9,8 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::Account;
 
+pub mod signature_messages;
+
 /// Error message for when the admin account is not found in the contract.
 pub const GOVERNANCE_NOT_FOUND: &str = "The governance does not exist";
 

--- a/core/src/governance/signature_messages.rs
+++ b/core/src/governance/signature_messages.rs
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! The signature messages for the respective governance contract functions.
+
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+use dusk_core::abi::{ContractId, CONTRACT_ID_BYTES};
+use dusk_core::signatures::bls::PublicKey;
+
+use crate::Account;
+
+// the max account size is the public key raw size `G2Affine::RAW_SIZE`
+const ACCOUNT_MAX_SIZE: usize = 194;
+
+/// The signature message for changing the token-contract is the current
+/// owner-nonce in be-bytes appended by the new token-contract `ContractId`.
+#[must_use]
+pub fn set_token_contract(
+    owner_nonce: u64,
+    new_token_contract: &ContractId,
+) -> Vec<u8> {
+    let mut sig_msg = Vec::with_capacity(size_of::<u64>() + CONTRACT_ID_BYTES);
+    sig_msg.extend(&owner_nonce.to_be_bytes());
+    sig_msg.extend(&new_token_contract.to_bytes());
+
+    sig_msg
+}
+
+/// The signature message for changing the owners, is the current
+/// owner-nonce in be-bytes appended by the serialized public-keys of
+/// the new owners.
+#[must_use]
+pub fn set_owners(
+    owner_nonce: u64,
+    new_owners: impl AsRef<[PublicKey]>,
+) -> Vec<u8> {
+    set_owner_or_operator(owner_nonce, new_owners)
+}
+
+/// The signature message for changing the operators, is the current
+/// owner-nonce in be-bytes appended by the serialized public-keys of
+/// the new operators.
+#[must_use]
+pub fn set_operators(
+    owner_nonce: u64,
+    new_operators: impl AsRef<[PublicKey]>,
+) -> Vec<u8> {
+    set_owner_or_operator(owner_nonce, new_operators)
+}
+
+#[must_use]
+fn set_owner_or_operator(
+    owner_nonce: u64,
+    new_keys: impl AsRef<[PublicKey]>,
+) -> Vec<u8> {
+    let new_keys = new_keys.as_ref();
+    let mut sig_msg = Vec::with_capacity(
+        size_of::<u64>() + new_keys.len() * ACCOUNT_MAX_SIZE,
+    );
+    sig_msg.extend(&owner_nonce.to_be_bytes());
+    new_keys
+        .iter()
+        .for_each(|pk| sig_msg.extend(&pk.to_raw_bytes()));
+
+    sig_msg
+}
+
+/// The signature message for transferring the governance of the
+/// token-contract is the current owner-nonce in big endian appended by the
+/// new governance.
+#[must_use]
+pub fn transfer_governance(
+    owner_nonce: u64,
+    new_governance: &Account,
+) -> Vec<u8> {
+    let mut sig_msg = Vec::with_capacity(size_of::<u64>() + ACCOUNT_MAX_SIZE);
+    sig_msg.extend(&owner_nonce.to_be_bytes());
+    sig_msg.extend(&account_to_bytes(new_governance));
+
+    sig_msg
+}
+
+#[must_use]
+fn account_to_bytes(account: &Account) -> Vec<u8> {
+    match account {
+        Account::External(pk) => pk.to_raw_bytes().to_vec(),
+        Account::Contract(id) => id.to_bytes().to_vec(),
+    }
+}
+
+/// The signature message for renouncing the governance of the
+/// token-contract is the current owner-nonce in big endian.
+#[must_use]
+pub fn renounce_governance(owner_nonce: u64) -> Vec<u8> {
+    owner_nonce.to_be_bytes().into()
+}
+
+/// The signature message for executing an operator approved token-contract
+/// call is the current operator-nonce in big endian, appended by the
+/// call-name and -arguments.
+#[must_use]
+pub fn operator_token_call(
+    operator_nonce: u64,
+    call_name: &str,
+    call_arguments: impl AsRef<[u8]>,
+) -> Vec<u8> {
+    let call_arguments = call_arguments.as_ref();
+    let call_name_bytes = call_name.as_bytes();
+    let mut sig_msg = Vec::with_capacity(
+        size_of::<u64>() + call_name_bytes.len() + call_arguments.len(),
+    );
+    sig_msg.extend(&operator_nonce.to_be_bytes());
+    sig_msg.extend(call_name_bytes);
+    sig_msg.extend(call_arguments);
+
+    sig_msg
+}
+
+/// The signature message for adding an operator token-contract call is the
+/// current operator-nonce in big endian, appended by the call-name as
+/// bytes and the signature threshold for that call.
+#[must_use]
+pub fn set_operator_token_call(
+    operator_nonce: u64,
+    call_name: &str,
+    operator_signature_threshold: u8,
+) -> Vec<u8> {
+    let call_name_bytes = call_name.as_bytes();
+    let mut sig_msg = Vec::with_capacity(
+        size_of::<u64>() + call_name_bytes.len() + size_of::<u8>(),
+    );
+    sig_msg.extend(&operator_nonce.to_be_bytes());
+    sig_msg.extend(call_name_bytes);
+    sig_msg.extend(&[operator_signature_threshold]);
+
+    sig_msg
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,8 @@
 
 /// Types used for administrative functions.
 pub mod admin_management;
+/// Error messages given by token or governance contract
+pub mod error;
 /// Types used for access control through governance.
 pub mod governance;
 /// Types used for sanctions.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,6 +20,8 @@
 )]
 #![deny(clippy::pedantic)]
 
+extern crate alloc;
+
 /// Types used for administrative functions.
 pub mod admin_management;
 /// Error messages given by token or governance contract

--- a/governance/Cargo.toml
+++ b/governance/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "emt-governance"
+version.workspace = true
+edition.workspace = true
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+dusk-core = { workspace = true, features = ["abi-dlmalloc"] }
+emt-core = { workspace = true }
+dusk-bytes = { workspace = true }
+
+[dev-dependencies]
+emt-tests = { workspace = true }
+emt-core = { workspace = true }
+dusk-bytes = { workspace = true }
+dusk-core = { workspace = true }
+dusk-vm = { workspace = true }
+rkyv = { workspace = true }
+bytecheck = { workspace = true }
+rand = { workspace = true, features = ["std_rng"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/governance/Makefile
+++ b/governance/Makefile
@@ -1,0 +1,27 @@
+TOKEN_WASM:="../target/wasm64-unknown-unknown/release/emt_token.wasm"
+GOVERNANCE_WASM:="../target/wasm64-unknown-unknown/release/emt_governance.wasm"
+
+all: ## Build the token contract
+	@cargo build --release
+
+help: ## Display this help screen
+	@grep -h \
+		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+$(TOKEN_WASM): ## Build token contract wasm file if it doesn't exist
+	$(MAKE) -C ../ token
+
+$(GOVERNANCE_WASM): ## Build governance contract wasm file if it doesn't exist
+	$(MAKE) -C ../ governance
+
+test: $(TOKEN_WASM) $(GOVERNANCE_WASM) ## Run the token contract tests
+	@cargo test --release -- --test-threads=1 # piecrust throws persistence error when using more threads
+
+clippy: ## Run clippy
+	@cargo +dusk clippy -Z build-std=core,alloc --release --target wasm64-unknown-unknown -- -D warnings
+
+doc: ## Build the docs
+	@cargo doc --release
+
+.PHONY: all test clippy doc

--- a/governance/src/lib.rs
+++ b/governance/src/lib.rs
@@ -1,0 +1,268 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! The governance contract for electronic money tokens.
+
+#![no_std]
+#![deny(unused_extern_crates)]
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::pedantic)]
+
+#[cfg(target_family = "wasm")]
+pub(crate) mod state;
+
+#[cfg(target_family = "wasm")]
+mod wasm {
+    extern crate alloc;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use dusk_core::{abi, signatures::bls::MultisigSignature};
+
+    use crate::state::STATE;
+
+    /*
+     * Basic contract implementation.
+     */
+
+    #[no_mangle]
+    unsafe extern "C" fn init(arg_len: u32) -> u32 {
+        abi::wrap_call(
+            arg_len,
+            |(token_contract, owner, operator, operator_token_call_data)| {
+                STATE.init(
+                    token_contract,
+                    owner,
+                    operator,
+                    operator_token_call_data,
+                );
+            },
+        )
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn token_contract(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(): ()| STATE.token_contract())
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn owners(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(): ()| STATE.owners())
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn owner_nonce(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(): ()| STATE.owner_nonce())
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn operators(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(): ()| STATE.operators())
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn operator_nonce(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(): ()| STATE.operator_nonce())
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn operator_signature_threshold(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |call_name: String| {
+            STATE.operator_signature_threshold(call_name.as_str())
+        })
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn authorize_owners(arg_len: u32) -> u32 {
+        abi::wrap_call(
+            arg_len,
+            |(threshold, sig_msg, sig, signers): (
+                u8,
+                Vec<u8>,
+                MultisigSignature,
+                Vec<u8>,
+            )| {
+                STATE.authorize_owners(threshold, sig_msg, sig, signers);
+            },
+        )
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn authorize_operators(arg_len: u32) -> u32 {
+        abi::wrap_call(
+            arg_len,
+            |(threshold, sig_msg, sig, signers): (
+                u8,
+                Vec<u8>,
+                MultisigSignature,
+                Vec<u8>,
+            )| {
+                STATE.authorize_operators(threshold, sig_msg, sig, signers);
+            },
+        )
+    }
+
+    /*
+     * Functions that need the owners' approval.
+     */
+
+    #[no_mangle]
+    unsafe extern "C" fn set_token_contract(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(new_token_contract, sig, signers)| {
+            STATE.set_token_contract(new_token_contract, sig, signers)
+        })
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn set_owners(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(new_owners, sig, signers)| {
+            STATE.set_owners(new_owners, sig, signers);
+        })
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn set_operators(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(new_operators, sig, signers)| {
+            STATE.set_operators(new_operators, sig, signers);
+        })
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn transfer_governance(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(new_governance, sig, signers)| {
+            STATE.transfer_governance(new_governance, sig, signers);
+        })
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn renounce_governance(arg_len: u32) -> u32 {
+        abi::wrap_call(arg_len, |(sig, signers)| {
+            STATE.renounce_governance(sig, signers);
+        })
+    }
+
+    /*
+     * Functions that need the operators' approval.
+     */
+
+    #[no_mangle]
+    unsafe extern "C" fn operator_token_call(arg_len: u32) -> u32 {
+        abi::wrap_call(
+            arg_len,
+            |(call_name, call_arguments, sig, signers): (
+                String,
+                Vec<u8>,
+                MultisigSignature,
+                Vec<u8>,
+            )| {
+                STATE.operator_token_call(
+                    call_name.as_str(),
+                    &call_arguments,
+                    sig,
+                    signers,
+                );
+            },
+        )
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn set_operator_token_call(arg_len: u32) -> u32 {
+        abi::wrap_call(
+            arg_len,
+            |(call_name, operator_signature_threshold, sig, signers)| {
+                STATE.set_operator_token_call(
+                    call_name,
+                    operator_signature_threshold,
+                    sig,
+                    signers,
+                );
+            },
+        )
+    }
+}
+
+/// Calculate the super-majority for the given amount eligible signers.
+///
+/// # Panics
+/// This function panics if the amount is 0 or larger than `u8::MAX`
+#[must_use]
+fn supermajority(amt: usize) -> u8 {
+    assert!(amt > 0, "Cannot calculate supermajority of 0");
+    let amt = u8::try_from(amt).expect(
+        "Neither owner nor operator key sets are larger than `u8::MAX`",
+    );
+    amt / 2 + 1
+}
+
+/// Checks whether a given set contains duplicate elements.
+#[must_use]
+fn contains_duplicates<T>(elements: impl AsRef<[T]>) -> bool
+where
+    T: PartialEq,
+{
+    let elements = elements.as_ref();
+    let len = elements.len();
+    if len > 0 {
+        for i in 0..len - 1 {
+            for j in i + 1..len {
+                if elements[i] == elements[j] {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supermajority() {
+        assert_eq!(supermajority(1), 1);
+        assert_eq!(supermajority(2), 2);
+        assert_eq!(supermajority(3), 2);
+        assert_eq!(supermajority(4), 3);
+        assert_eq!(supermajority(5), 3);
+        assert_eq!(supermajority(42), 22);
+        assert_eq!(supermajority(101), 51);
+        assert_eq!(supermajority(u8::MAX as usize), 128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot calculate supermajority of 0")]
+    fn test_supermajority_lower_bound() {
+        let _ = supermajority(0);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Neither owner nor operator key sets are larger than `u8::MAX`"
+    )]
+    fn test_supermajority_upper_bound() {
+        let _ = supermajority(u8::MAX as usize + 1);
+    }
+
+    #[test]
+    fn test_contains_duplicates() {
+        // test sets without duplicates
+        let empty: [u32; 0] = [];
+        assert!(!contains_duplicates(empty));
+        assert!(!contains_duplicates([1]));
+        assert!(!contains_duplicates([1, 2, 3]));
+        assert!(!contains_duplicates([1, 2, 3, 4, 5]));
+
+        // test sets without duplicates
+        assert!(contains_duplicates([1, 1]));
+        assert!(contains_duplicates([1, 2, 2]));
+        assert!(contains_duplicates([1, 1, 2, 3]));
+        assert!(contains_duplicates([1, 2, 3, 3]));
+        assert!(contains_duplicates([1, 2, 2, 3]));
+        assert!(contains_duplicates([1, 2, 3, 3, 4, 5]));
+    }
+}

--- a/governance/src/state.rs
+++ b/governance/src/state.rs
@@ -1,0 +1,600 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use dusk_core::abi::{self, ContractId, CONTRACT_ID_BYTES};
+use dusk_core::signatures::bls::{MultisigSignature, PublicKey};
+use emt_core::governance::signature_messages;
+use emt_core::{error, Account};
+
+use crate::{contains_duplicates, supermajority};
+
+const EMPTY: ContractId = ContractId::from_bytes([0u8; CONTRACT_ID_BYTES]);
+
+/// The state of the token governance contract.
+pub struct Governance {
+    // The contract-id of the token-contract.
+    token_contract: ContractId,
+    // Only the owners of a token-contract are authorized to change the owners
+    // or operators of the token-contract.
+    owners: Vec<PublicKey>,
+    // The nonce for the owners, initialized at 0 and strictly increasing.
+    owner_nonce: u64,
+    // The operators of the token-contract are authorized to execute all
+    // inter-contract calls to the token-contract except changing governance.
+    operators: Vec<PublicKey>,
+    // The nonce for the operators, initialized at 0 and strictly increasing.
+    operator_nonce: u64,
+    // A map for all the inter-contract calls to the token-contract, that are
+    // executable by the operators. Each call has a threshold of signers
+    // that are required for its execution. If the threshold for a call is set
+    // to 0, a super-majority of signers is needed.
+    operator_token_calls: BTreeMap<String, u8>,
+}
+
+/// The state of the governance contract at deployment.
+pub static mut STATE: Governance = Governance::new();
+
+/// Basic contract implementation.
+impl Governance {
+    /// Create a new empty instance of the governance-contract.
+    #[must_use]
+    const fn new() -> Self {
+        Self {
+            token_contract: EMPTY,
+            owners: Vec::new(),
+            owner_nonce: 0,
+            operators: Vec::new(),
+            operator_nonce: 0,
+            operator_token_calls: BTreeMap::new(),
+        }
+    }
+
+    /// Initialize the governance contract state with sets of owners, operators
+    /// and inter-contract calls.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The contract is already initialized.
+    /// - The given set of owner keys is empty.
+    /// - The given set of owner keys is larger than `u8::MAX`.
+    /// - The given set of operator keys is larger than `u8::MAX`.
+    /// - There are duplicate owner keys.
+    /// - There are duplicate operator keys.
+    /// - One of the new operator-calls is reserved for owner-calls.
+    pub fn init(
+        &mut self,
+        token_contract: ContractId,
+        owners: Vec<PublicKey>,
+        operators: Vec<PublicKey>,
+        operator_token_call_data: Vec<(String, u8)>,
+    ) {
+        // panic if the contract has already been initialized
+        assert!(self.owners.is_empty(), "{}", error::ALLREADY_INITIALIZED);
+        // panic if no owners are given
+        assert!(!owners.is_empty(), "{}", error::EMPTY_OWNER);
+        // panic if there are more than `u8::MAX` owners
+        assert!(
+            !owners.len() > u8::MAX as usize,
+            "{}",
+            error::TOO_MANY_OWNERS
+        );
+        // panic if there are more than `u8::MAX` operators
+        assert!(
+            !owners.len() > u8::MAX as usize,
+            "{}",
+            error::TOO_MANY_OPERATORS
+        );
+        // panic if there are duplicate owners
+        assert!(!contains_duplicates(&owners), "{}", error::DUPLICATE_OWNER);
+
+        // initialize token-contract and owners
+        self.token_contract = token_contract;
+        self.owners = owners;
+
+        // initialize operators (if any)
+        if !operators.is_empty() {
+            // panic if there are duplicate operators
+            assert!(
+                !contains_duplicates(&operators),
+                "{}",
+                error::DUPLICATE_OPERATOR
+            );
+            self.operators = operators;
+        }
+
+        // initialize inter-contract calls (if any)
+        let mut operator_token_calls = BTreeMap::new();
+        for (call_name, signature_threshold) in operator_token_call_data {
+            // panic if inter-contract calls that need owner approval are
+            // added
+            assert!(
+                !Self::OWNER_TOKEN_CALLS.contains(&call_name.as_str()),
+                "{}",
+                error::UNAUTHORIZED_TOKEN_CALL,
+            );
+            operator_token_calls.insert(call_name, signature_threshold);
+        }
+        self.operator_token_calls = operator_token_calls;
+    }
+
+    /// Return the linked token-contract.
+    #[must_use]
+    pub fn token_contract(&self) -> ContractId {
+        self.token_contract
+    }
+
+    /// Return the current owners stored in the governance-contract.
+    #[must_use]
+    pub fn owners(&self) -> Vec<PublicKey> {
+        self.owners.clone()
+    }
+
+    /// Return the current nonce for executing anything that requires a
+    /// signature of the owners.
+    #[must_use]
+    pub fn owner_nonce(&self) -> u64 {
+        self.owner_nonce
+    }
+
+    /// Return the current operators stored in the governance contract.
+    #[must_use]
+    pub fn operators(&self) -> Vec<PublicKey> {
+        self.operators.clone()
+    }
+
+    /// Return the current nonce for executing anything that requires a
+    /// signature of the operators.
+    #[must_use]
+    pub fn operator_nonce(&self) -> u64 {
+        self.operator_nonce
+    }
+
+    /// Return the minimum amount of operators that must sign a given call to
+    /// the token-contract in order for it to be executed.
+    /// If the stored signature threshold for a call is 0, the super-majority is
+    /// calculated and returned.
+    /// Returns `None` if the `call_name` is not a registered operators
+    /// token-contract call.
+    #[must_use]
+    pub fn operator_signature_threshold(&self, call_name: &str) -> Option<u8> {
+        self.operator_token_calls
+            .get(call_name)
+            .copied()
+            .map(|threshold| match threshold {
+                0 => supermajority(self.operators.len()),
+                _ => threshold,
+            })
+    }
+}
+
+// Methods that need the owners' approval.
+impl Governance {
+    /// Since the token-contract will execute every inter-contract call that
+    /// comes from the governance contract, every token-contract call that need
+    /// authorization by the owners **must** be excluded from the calls that the
+    /// operators need to authorize.
+    const OWNER_TOKEN_CALLS: [&'static str; 2] = [
+        // 'set_token_contract`, `set_owners` and `set_operators` also need
+        // owners approval but because they don't contain a call to the
+        // token-contract, they don't need to be added here.
+        "transfer_governance",
+        "renounce_governance",
+    ];
+
+    /// Update the token-contract in the governance-contract and return the old
+    /// token-contract ID.
+    /// This allows for changing the token-contract while keeping the same
+    /// governance.
+    ///
+    /// The signature message for this inter-contract call is the current
+    /// owner-nonce in be-bytes appended by the new token-contract `ContractId`.
+    ///
+    /// Note: A super-majority of owner signatures is required to perform this
+    /// action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of owners
+    #[must_use]
+    pub fn set_token_contract(
+        &mut self,
+        new_token_contract: ContractId,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) -> ContractId {
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.owners.len());
+
+        // check the signature
+        let sig_msg = signature_messages::set_token_contract(
+            self.owner_nonce,
+            &new_token_contract,
+        );
+        self.authorize_owners(threshold, sig_msg, sig, signers);
+
+        // increment the owners nonce
+        self.owner_nonce += 1;
+
+        // replace the token-contract
+        core::mem::replace(&mut self.token_contract, new_token_contract)
+    }
+
+    /// Update the owner public-keys in the governance-contract.
+    ///
+    /// The signature message for this inter-contract call is the current
+    /// owner-nonce in be-bytes appended by the serialized public-keys of
+    /// the new owners.
+    ///
+    /// Note: A super-majority of owner signatures is required to perform this
+    /// action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of owners
+    /// - The new set of owner keys is empty.
+    /// - The new set of owner keys is larger than `u8::MAX`.
+    /// - The new set of owner keys contains duplicates.
+    pub fn set_owners(
+        &mut self,
+        new_owners: Vec<PublicKey>,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // panic if no owners are given
+        assert!(!new_owners.is_empty(), "{}", error::EMPTY_OWNER);
+        // panic if more than `u8::MAX` owners are given
+        assert!(
+            !new_owners.len() > u8::MAX as usize,
+            "{}",
+            error::TOO_MANY_OWNERS
+        );
+        // panic if there are duplicate owners
+        assert!(
+            !contains_duplicates(&new_owners),
+            "{}",
+            error::DUPLICATE_OWNER
+        );
+
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.owners.len());
+
+        // check the signature
+        let sig_msg =
+            signature_messages::set_owners(self.owner_nonce, &new_owners);
+        self.authorize_owners(threshold, sig_msg, sig, signers);
+
+        // update the owners to the new set
+        self.owners = new_owners;
+
+        // increment the owners nonce
+        self.owner_nonce += 1;
+    }
+
+    /// Update the operator public-keys in the governance-contract.
+    ///
+    /// The signature message for this inter-contract call is the current
+    /// owner-nonce in be-bytes appended by the serialized public-keys of
+    /// the new operators.
+    ///
+    /// Note: A super-majority of owner signatures is required to perform this
+    /// action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of owners
+    /// - The new set of operator keys is larger than `u8::MAX`.
+    /// - The new set of operator keys contains duplicates.
+    pub fn set_operators(
+        &mut self,
+        new_operators: Vec<PublicKey>,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // panic if more than `u8::MAX` operators are given
+        assert!(
+            !new_operators.len() > u8::MAX as usize,
+            "{}",
+            error::TOO_MANY_OPERATORS
+        );
+        // panic if there are duplicate operators
+        assert!(
+            !contains_duplicates(&new_operators),
+            "{}",
+            error::DUPLICATE_OPERATOR
+        );
+
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.owners.len());
+
+        // check the signature
+        let sig_msg =
+            signature_messages::set_operators(self.owner_nonce, &new_operators);
+        self.authorize_owners(threshold, sig_msg, sig, signers);
+
+        // update the operators to the new set
+        self.operators = new_operators;
+
+        // increment the owners nonce
+        self.owner_nonce += 1;
+    }
+
+    /// Authorize the transfer of the governance stored in the state of the
+    /// token-contract to a new account. After executing this call, this
+    /// governance contract will **no longer be authorized** to do any
+    /// inter-contract calls on the token-contract and the new account needs to
+    /// be used for authorization instead.
+    ///
+    /// The signature message for transferring the governance of the
+    /// token-contract is the current owner-nonce in big endian appended by the
+    /// new governance.
+    ///
+    /// Note: A super-majority of owner signatures is required to perform this
+    /// action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of owners
+    pub fn transfer_governance(
+        &mut self,
+        new_governance: Account,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.owners.len());
+
+        // check the signature
+        let sig_msg = signature_messages::transfer_governance(
+            self.owner_nonce,
+            &new_governance,
+        );
+        self.authorize_owners(threshold, sig_msg, sig, signers);
+
+        // transfer the ownership of the token-contract
+        let _: () = abi::call(
+            self.token_contract(),
+            "transfer_governance",
+            &new_governance,
+        )
+        .expect("transferring the governance should succeed");
+
+        // increment the owners nonce
+        self.owner_nonce += 1;
+    }
+
+    /// Renounce the governance of the token-contract.
+    /// Note: After executing this call, neither this governance-contract nor
+    /// any other account will be authorized to call any functions on the
+    /// token-contract that require authorization from the governance account.
+    ///
+    /// The signature message for renouncing the governance of the
+    /// token-contract is the current owner-nonce in big endian.
+    ///
+    /// Note: A super-majority of owner signatures is required to perform this
+    /// action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of owners
+    pub fn renounce_governance(
+        &mut self,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.owners.len());
+
+        // check the signature
+        let sig_msg = signature_messages::renounce_governance(self.owner_nonce);
+        self.authorize_owners(threshold, sig_msg, sig, signers);
+
+        // removing the governance on the token-contract
+        let _: () =
+            abi::call(self.token_contract(), "renounce_governance", &())
+                .expect("renouncing the governance should succeed");
+
+        // increment the owners nonce
+        self.owner_nonce += 1;
+    }
+}
+
+// Methods that need the operators' approval
+impl Governance {
+    /// Execute a call to the token-contract, that doesn't require owner's
+    /// approval.
+    ///
+    /// The signature message for executing an operator approved token-contract
+    /// call is the current operator-nonce in big endian, appended by the
+    /// call-name and -arguments.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by the required threshold of
+    ///   operators
+    /// - The `call_name` is not registered in the contract-state.
+    pub fn operator_token_call(
+        &mut self,
+        call_name: &str,
+        call_arguments: &[u8],
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // get the stored threshold for this operation
+        let threshold = self
+            .operator_signature_threshold(call_name)
+            .unwrap_or_else(|| panic!("{}", error::TOKEN_CALL_NOT_FOUND));
+
+        // check the signature
+        let sig_msg = signature_messages::operator_token_call(
+            self.operator_nonce,
+            call_name,
+            call_arguments,
+        );
+        self.authorize_operators(threshold, sig_msg, sig, signers);
+
+        // call the specified method of the token-contract
+        let _ = abi::call_raw(self.token_contract(), call_name, call_arguments)
+            .expect(error::OPERATOR_TOKEN_CALL_PANIC);
+
+        // increment the operator nonce
+        self.operator_nonce += 1;
+    }
+
+    /// Add a new call to the stored set of operator calls or update the call
+    /// threshold if it already exists. A threshold of 0 means that the call
+    /// needs a super-majority of operator-signatures to be executed.
+    ///
+    /// The signature message for adding an operator token-contract call is the
+    /// current operator-nonce in big endian, appended by the call-name as
+    /// bytes and the signature threshold for that call.
+    ///
+    /// Note: A super-majority of operator signatures is required to perform
+    /// this action.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect or not signed by a super-majority of
+    ///   operators
+    /// - The new operator-calls is reserved for owner-calls.
+    pub fn set_operator_token_call(
+        &mut self,
+        call_name: String,
+        operator_signature_threshold: u8,
+        sig: MultisigSignature,
+        signers: Vec<u8>,
+    ) {
+        // panic if inter-contract calls that need owner approval are added
+        assert!(
+            !Self::OWNER_TOKEN_CALLS.contains(&call_name.as_str()),
+            "{}",
+            error::UNAUTHORIZED_TOKEN_CALL,
+        );
+
+        // the threshold needs to be a super-majority
+        let threshold = supermajority(self.operators.len());
+
+        // check the signature
+        let sig_msg = signature_messages::set_operator_token_call(
+            self.operator_nonce,
+            call_name.as_str(),
+            operator_signature_threshold,
+        );
+        self.authorize_operators(threshold, sig_msg, sig, signers);
+
+        // add the call or update its threshold if it already exists
+        self.operator_token_calls
+            .insert(call_name, operator_signature_threshold);
+
+        // increment the operator nonce
+        self.operator_nonce += 1;
+    }
+}
+
+/// Access control implementation.
+impl Governance {
+    /// Check if the aggregated signature of the given owners is valid.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect given the signature-message and public-keys
+    /// - There are less signers than the specified threshold
+    /// - One of the signers exceeds the owner-index
+    /// - There are duplicate signers
+    pub fn authorize_owners(
+        &self,
+        threshold: u8,
+        sig_msg: Vec<u8>,
+        sig: MultisigSignature,
+        signers: impl AsRef<[u8]>,
+    ) {
+        self.authorize(threshold, sig_msg, sig, signers, true);
+    }
+
+    /// Check if the aggregated signature of the given operators is valid.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect given the signature-message and public-keys
+    /// - There are less signers than the specified threshold
+    /// - One of the signers exceeds the operator-index
+    /// - There are duplicate signers
+    pub fn authorize_operators(
+        &self,
+        threshold: u8,
+        sig_msg: Vec<u8>,
+        sig: MultisigSignature,
+        signers: impl AsRef<[u8]>,
+    ) {
+        self.authorize(threshold, sig_msg, sig, signers, false);
+    }
+
+    /// Check if the given aggregated signature is correct given the public-keys
+    /// and that the signer threshold is met.
+    ///
+    /// # Panics
+    /// This function will panic if:
+    /// - The signature is incorrect given the signature-message and public-keys
+    /// - The public-keys are less than the specified threshold
+    fn authorize(
+        &self,
+        threshold: u8,
+        sig_msg: Vec<u8>,
+        sig: MultisigSignature,
+        signers: impl AsRef<[u8]>,
+        is_owner: bool,
+    ) {
+        let signer_idx = signers.as_ref();
+
+        // at this point the threshold should never be 0
+        assert!(threshold > 0, "{}", error::THRESHOLD_ZERO);
+
+        // panic if the signers contain duplicates
+        assert!(
+            !contains_duplicates(signer_idx),
+            "{}",
+            error::DUPLICATE_SIGNER
+        );
+
+        // panic if one of the signer's indices doesn't exist
+        assert!(
+            (signer_idx.iter().max().copied().unwrap_or_default() as usize)
+                < self.owners.len(),
+            "{}",
+            error::SIGNER_NOT_FOUND
+        );
+
+        // panic if the threshold of signers is not met
+        assert!(
+            signer_idx.len() >= threshold as usize,
+            "{}",
+            error::THRESHOLD_NOT_MET
+        );
+
+        // get the signers public keys
+        let public_keys = if is_owner {
+            self.owners()
+        } else {
+            self.operators()
+        };
+        let signers: Vec<PublicKey> = signer_idx
+            .iter()
+            .map(|index| public_keys[*index as usize])
+            .collect();
+
+        // verify the signature
+        assert!(
+            abi::verify_bls_multisig(sig_msg, signers, sig),
+            "{}",
+            error::INVALID_SIGNATURE
+        );
+    }
+}

--- a/governance/tests/common/instantiate.rs
+++ b/governance/tests/common/instantiate.rs
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_core::abi::{ContractError, ContractId, StandardBufSerializer};
+use dusk_core::dusk;
+use dusk_core::signatures::bls::{
+    PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
+};
+use dusk_vm::{CallReceipt, ContractData, Error as VMError};
+
+use bytecheck::CheckBytes;
+
+use rkyv::validation::validators::DefaultValidator;
+use rkyv::{Archive, Deserialize, Infallible, Serialize};
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use emt_core::Account;
+
+use emt_tests::network::NetworkSession;
+
+const TOKEN_BYTECODE: &[u8] = include_bytes!(
+    "../../../target/wasm64-unknown-unknown/release/emt_token.wasm"
+);
+const GOVERNANCE_BYTECODE: &[u8] = include_bytes!(
+    "../../../target/wasm64-unknown-unknown/release/emt_governance.wasm"
+);
+
+const DEPLOYER: [u8; 64] = [0u8; 64];
+
+pub const TOKEN_ID: ContractId = ContractId::from_bytes([1; 32]);
+pub const GOVERNANCE_ID: ContractId = ContractId::from_bytes([2; 32]);
+
+pub const INITIAL_BALANCE: u64 = 1000;
+
+type Result<T, Error = VMError> = core::result::Result<T, Error>;
+
+pub struct TestKeys<const O: usize, const P: usize, const H: usize> {
+    pub owners_sk: [AccountSecretKey; O],
+    pub owners_pk: [AccountPublicKey; O],
+    pub operators_sk: [AccountSecretKey; P],
+    pub operators_pk: [AccountPublicKey; P],
+    pub test_sk: [AccountSecretKey; H],
+    pub test_pk: [AccountPublicKey; H],
+}
+
+impl<const O: usize, const P: usize, const H: usize> TestKeys<O, P, H> {
+    pub fn new() -> Self {
+        let mut rng = StdRng::seed_from_u64(0x5EAF00D);
+
+        // generate owners keys
+        let mut owners_sk = Vec::with_capacity(O);
+        let mut owners_pk = Vec::with_capacity(O);
+        for _ in 0..O {
+            let sk = AccountSecretKey::random(&mut rng);
+            let pk = AccountPublicKey::from(&sk);
+            owners_sk.push(sk);
+            owners_pk.push(pk);
+        }
+
+        // generate operators keys
+        let mut operators_sk = Vec::with_capacity(P);
+        let mut operators_pk = Vec::with_capacity(P);
+        for _ in 0..P {
+            let sk = AccountSecretKey::random(&mut rng);
+            let pk = AccountPublicKey::from(&sk);
+            operators_sk.push(sk);
+            operators_pk.push(pk);
+        }
+
+        // generate test keys
+        let mut test_sk = Vec::with_capacity(H);
+        let mut test_pk = Vec::with_capacity(H);
+        for _ in 0..H {
+            let sk = AccountSecretKey::random(&mut rng);
+            let pk = AccountPublicKey::from(&sk);
+            test_sk.push(sk);
+            test_pk.push(pk);
+        }
+
+        Self {
+            owners_sk: owners_sk.try_into().unwrap(),
+            owners_pk: owners_pk.try_into().unwrap(),
+            operators_sk: operators_sk.try_into().unwrap(),
+            operators_pk: operators_pk.try_into().unwrap(),
+            test_sk: test_sk.try_into().unwrap(),
+            test_pk: test_pk.try_into().unwrap(),
+        }
+    }
+}
+
+pub struct TestSession {
+    session: NetworkSession,
+}
+
+impl TestSession {
+    pub fn new<const O: usize, const P: usize, const H: usize>() -> Self {
+        let test_keys: TestKeys<O, P, H> = TestKeys::new();
+
+        // deploy a session with transfer & stake contract deployed and a list
+        // of public accounts that own DUSK for gas-costs
+        const MOONLIGHT_BALANCE: u64 = dusk(1_000.0);
+        let mut public_keys = Vec::with_capacity(O + P + H);
+        public_keys.extend_from_slice(&test_keys.owners_pk);
+        public_keys.extend_from_slice(&test_keys.operators_pk);
+        public_keys.extend_from_slice(&test_keys.test_pk);
+        let public_balances = public_keys
+            .iter()
+            .map(|pk| (pk, MOONLIGHT_BALANCE))
+            .collect();
+        let mut network_session = NetworkSession::instantiate(public_balances);
+
+        // deploy the token-contract
+        // fund all keys and the governance-contract itself with an initial
+        // balance
+        let mut initial_balances = public_keys
+            .iter()
+            .map(|pk| (Account::from(*pk), INITIAL_BALANCE))
+            .collect::<Vec<_>>();
+        initial_balances
+            .push((Account::Contract(GOVERNANCE_ID), INITIAL_BALANCE));
+        let token_init_args = (
+            initial_balances,
+            // set the governance-contract as token-contract governance
+            Account::from(GOVERNANCE_ID),
+        );
+        network_session
+            .deploy(
+                TOKEN_BYTECODE,
+                ContractData::builder()
+                    .owner(DEPLOYER)
+                    .init_arg(&token_init_args)
+                    .contract_id(TOKEN_ID),
+            )
+            .expect("Deploying the token-contract should succeed");
+
+        // deploy the governance-contract
+        let governance_init_args = (
+            // set the token-contract in the governance state
+            TOKEN_ID,
+            // set the owner and operator keys
+            test_keys.owners_pk.to_vec(),
+            test_keys.operators_pk.to_vec(),
+            // register all operator token-contract calls
+            vec![
+                // block and freeze need 1 sig
+                ("block".to_string(), 1),
+                ("freeze".to_string(), 1),
+                ("unblock".to_string(), 1),
+                ("unfreeze".to_string(), 1),
+                // everything else needs a supermajority
+                ("mint".to_string(), 0),
+                ("burn".to_string(), 0),
+                ("toggle_pause".to_string(), 0),
+                ("force_transfer".to_string(), 0),
+            ],
+        );
+        network_session
+            .deploy(
+                GOVERNANCE_BYTECODE,
+                ContractData::builder()
+                    .owner(DEPLOYER)
+                    .init_arg(&governance_init_args)
+                    .contract_id(GOVERNANCE_ID),
+            )
+            .expect("Deploying the governance-contract should succeed");
+
+        let session = Self {
+            session: network_session,
+        };
+
+        session
+    }
+
+    /// Execute a state-transition of the governance-contract, paying gas with
+    /// `tx_sk`.
+    pub fn execute_governance<A, R>(
+        &mut self,
+        tx_sk: &AccountSecretKey,
+        fn_name: &str,
+        fn_arg: &A,
+    ) -> Result<CallReceipt<R>, ContractError>
+    where
+        A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible>
+            + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        self.session
+            .icc_transaction(tx_sk, GOVERNANCE_ID, fn_name, fn_arg)
+    }
+
+    /// Query the governance-contract directly without paying gas.
+    pub fn query_governance<A, R>(
+        &mut self,
+        fn_name: &str,
+        fn_arg: &A,
+    ) -> Result<CallReceipt<R>, ContractError>
+    where
+        A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible>
+            + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        self.session
+            .direct_call::<A, R>(GOVERNANCE_ID, fn_name, fn_arg)
+    }
+
+    /// Query the token-contract directly without paying gas.
+    pub fn query_token<A, R>(
+        &mut self,
+        fn_name: &str,
+        fn_arg: &A,
+    ) -> Result<CallReceipt<R>, ContractError>
+    where
+        A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible>
+            + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        self.session.direct_call::<A, R>(TOKEN_ID, fn_name, fn_arg)
+    }
+}

--- a/governance/tests/common/mod.rs
+++ b/governance/tests/common/mod.rs
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_core::signatures::bls::{
+    MultisigSignature, PublicKey as AccountPublicKey,
+    SecretKey as AccountSecretKey,
+};
+
+pub mod instantiate;
+use instantiate::TestKeys;
+
+pub fn owner_signature<const O: usize, const P: usize, const H: usize>(
+    keys: &TestKeys<O, P, H>,
+    sig_msg: &[u8],
+    signer_idx: &[u8],
+) -> MultisigSignature {
+    signature(
+        &keys.owners_sk[..],
+        &keys.owners_pk[..],
+        sig_msg,
+        signer_idx,
+    )
+}
+
+pub fn operator_signature<const O: usize, const P: usize, const H: usize>(
+    keys: &TestKeys<O, P, H>,
+    sig_msg: &[u8],
+    signer_idx: &[u8],
+) -> MultisigSignature {
+    signature(
+        &keys.operators_sk[..],
+        &keys.operators_pk[..],
+        sig_msg,
+        signer_idx,
+    )
+}
+
+#[allow(dead_code)]
+pub fn test_keys_signature<const O: usize, const P: usize, const H: usize>(
+    keys: &TestKeys<O, P, H>,
+    sig_msg: &[u8],
+    signer_idx: &[u8],
+) -> MultisigSignature {
+    signature(&keys.test_sk[..], &keys.test_pk[..], sig_msg, signer_idx)
+}
+
+fn signature(
+    sks: &[AccountSecretKey],
+    pks: &[AccountPublicKey],
+    sig_msg: &[u8],
+    signer_idx: &[u8],
+) -> MultisigSignature {
+    let sigs: Vec<MultisigSignature> = signer_idx
+        .iter()
+        .map(|idx| {
+            sks[*idx as usize].sign_multisig(&pks[*idx as usize], sig_msg)
+        })
+        .collect();
+
+    let multisig = sigs[0];
+    if sigs.len() > 1 {
+        multisig.aggregate(&sigs[1..])
+    } else {
+        multisig
+    }
+}

--- a/governance/tests/general.rs
+++ b/governance/tests/general.rs
@@ -1,0 +1,543 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_core::abi::{ContractError, ContractId};
+use dusk_core::signatures::bls::{
+    MultisigSignature, PublicKey as AccountPublicKey,
+};
+
+use emt_core::{error, Account, AccountInfo};
+
+mod common;
+use common::instantiate::{TestKeys, TestSession, INITIAL_BALANCE, TOKEN_ID};
+use common::{operator_signature, owner_signature, test_keys_signature};
+
+const OWNER: usize = 10;
+const OPERATOR: usize = 10;
+const TEST: usize = 10;
+
+#[test]
+fn init() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+
+    // check correct initialization of token-contract
+    assert_eq!(
+        session
+            .query_governance::<(), ContractId>("token_contract", &())?
+            .data,
+        TOKEN_ID,
+    );
+
+    // check correct initialization of owners and operators
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("owners", &())?
+            .data,
+        keys.owners_pk
+    );
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        0
+    );
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("operators", &())?
+            .data,
+        keys.operators_pk
+    );
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        0
+    );
+
+    // check initialization of operator's token-contract calls and signature
+    // thresholds
+    assert_eq!(
+        session
+            .query_governance::<String, Option<u8>>(
+                "operator_signature_threshold",
+                &"block".to_string(),
+            )?
+            .data,
+        Some(1)
+    );
+    assert_eq!(
+        session
+            .query_governance::<String, Option<u8>>(
+                "operator_signature_threshold",
+                &"mint".to_string(),
+            )?
+            .data,
+        Some(6)
+    );
+    assert_eq!(
+        session
+            .query_governance::<String, Option<u8>>(
+                "operator_signature_threshold",
+                &"force_transfer".to_string(),
+            )?
+            .data,
+        Some(6)
+    );
+
+    // technically not required here since it is checking the behavior of the
+    // token-contract, but for making sure the tests are correctly
+    // initialized we want to make sure that the keys have the expected
+    // token balance
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>(
+                "account",
+                &Account::from(keys.test_pk[0]),
+            )?
+            .data
+            .balance,
+        INITIAL_BALANCE,
+    );
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>(
+                "account",
+                &Account::from(keys.owners_pk[5]),
+            )?
+            .data
+            .balance,
+        INITIAL_BALANCE,
+    );
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>(
+                "account",
+                &Account::from(keys.operators_pk[9]),
+            )?
+            .data
+            .balance,
+        INITIAL_BALANCE,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn double_init_fails() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+
+    // create new init arguments with different owner and operator keys
+    let governance_init_args = (
+        TOKEN_ID,
+        keys.test_pk[..5].to_vec(),
+        keys.test_pk[5..].to_vec(),
+        vec![],
+    );
+
+    // double init should return an error
+    session
+        .execute_governance::<(
+            ContractId,
+            Vec<AccountPublicKey>,
+            Vec<AccountPublicKey>,
+            Vec<(String, u8)>,
+        ), ()>(&keys.test_sk[0], "init", &governance_init_args)
+        .expect_err("Call should not pass");
+
+    // check that owner didn't change
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("owners", &())?
+            .data,
+        keys.owners_pk,
+    );
+
+    // check that operator didn't change
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("operators", &())?
+            .data,
+        keys.operators_pk,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn authorize_owners_passes() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let sig_msg = rand::random::<[u8; 32]>().to_vec();
+
+    // more signers than threshold
+    let threshold = 6;
+    let signers = vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_owners",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // more signers than threshold
+    let threshold = 1;
+    let signers = vec![0u8, 6, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_owners",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 1;
+    let signers = vec![6u8];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_owners",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 10;
+    let signers = vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_owners",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 6;
+    let signers = vec![1u8, 3, 4, 5, 7, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_owners",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    Ok(())
+}
+
+#[test]
+fn authorize_owners_fails() -> Result<(), ContractError> {
+    // we need one less owner key in the test session
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<{ OWNER + 1 }, OPERATOR, TEST> = TestKeys::new();
+    let sig_msg = rand::random::<[u8; 32]>().to_vec();
+
+    // threshold is zero
+    let threshold = 0;
+    let signers = vec![0u8, 1, 2, 3, 4];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_ZERO);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // duplicate signer
+    let threshold = 2;
+    let signers = vec![0u8, 0];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::DUPLICATE_SIGNER);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // invalid signer index, since we initialized the session with 10 owner
+    // keys, the index = 10 is invalid
+    let threshold = 1;
+    let signers = vec![10u8];
+    println!("here");
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::SIGNER_NOT_FOUND);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // less signers than threshold
+    let threshold = 6;
+    let signers = vec![0u8, 1, 2, 3, 4];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_NOT_MET);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // operator signature fails
+    let threshold = 6;
+    let signers = vec![0u8, 1, 3, 4, 6, 7];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // test-keys signature fails
+    let threshold = 1;
+    let signers = vec![3u8];
+    let sig = test_keys_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_owners",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn authorize_operators_passes() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let sig_msg = rand::random::<[u8; 32]>().to_vec();
+
+    // more signers than threshold
+    let threshold = 6;
+    let signers = vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_operators",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // more signers than threshold
+    let threshold = 4;
+    let signers = vec![0u8, 6, 7, 8, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_operators",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 2;
+    let signers = vec![6u8, 8];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_operators",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 10;
+    let signers = vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_operators",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    // signers equal threshold
+    let threshold = 6;
+    let signers = vec![1u8, 3, 4, 5, 7, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    assert_eq!(
+        session
+            .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+                "authorize_operators",
+                &(threshold, sig_msg.clone(), sig, signers)
+            )?
+            .data,
+        (),
+    );
+
+    Ok(())
+}
+
+#[test]
+fn authorize_operators_fails() -> Result<(), ContractError> {
+    // we need one less owner key in the test session
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, { OPERATOR + 2 }, TEST> = TestKeys::new();
+    let sig_msg = rand::random::<[u8; 32]>().to_vec();
+
+    // threshold is zero
+    let threshold = 0;
+    let signers = vec![0u8];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_ZERO);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // duplicate signer
+    let threshold = 5;
+    let signers = vec![3u8, 4, 5, 6, 5];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::DUPLICATE_SIGNER);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // invalid signer index, since we initialized the session with 10 operator
+    // keys, the index = 11 is invalid
+    let threshold = 3;
+    let signers = vec![2u8, 4, 11];
+    println!("here");
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::SIGNER_NOT_FOUND);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // less signers than threshold
+    let threshold = 6;
+    let signers = vec![0u8, 1, 2, 3, 4];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_NOT_MET);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // owner signature fails
+    let threshold = 4;
+    let signers = vec![0u8, 3, 4, 7];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    // test-keys signature fails
+    let threshold = 1;
+    let signers = vec![3u8];
+    let sig = test_keys_signature(&keys, &sig_msg, &signers);
+    let contract_err = session
+        .query_governance::<(u8, Vec<u8>, MultisigSignature, Vec<u8>), ()>(
+            "authorize_operators",
+            &(threshold, sig_msg.clone(), sig, signers),
+        )
+        .expect_err("Call should panic");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    Ok(())
+}

--- a/governance/tests/operators.rs
+++ b/governance/tests/operators.rs
@@ -1,0 +1,474 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_core::abi::ContractError;
+use emt_core::error;
+use emt_core::governance::signature_messages;
+use emt_core::{Account, AccountInfo};
+use emt_tests::utils::rkyv_serialize;
+
+pub mod common;
+use common::instantiate::{
+    TestKeys, TestSession, GOVERNANCE_ID, INITIAL_BALANCE,
+};
+use common::{operator_signature, test_keys_signature};
+
+const OWNER: usize = 10;
+const OPERATOR: usize = 10;
+const TEST: usize = 10;
+
+/*
+ * Test `operator_token_call`
+ */
+
+#[test]
+fn unregistered_operator_token_call_fails() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let operator_nonce = 0u64;
+
+    // generate signature
+    let token_call_name = String::from("unregistered_call");
+    let token_call_args = rkyv_serialize(&());
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![3u8];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::TOKEN_CALL_NOT_FOUND);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check operator nonce is not incremented
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn freeze_operator_token_call() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut operator_nonce = 0u64;
+
+    // generate signature
+    let token_call_name = String::from("freeze");
+    let freeze_account = Account::External(keys.test_pk[0]);
+    let token_call_args = rkyv_serialize(&freeze_account);
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![7u8];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check account is frozen on token-contract
+    assert_eq!(
+        session
+            .query_token::<Account, bool>("frozen", &freeze_account)?
+            .data,
+        true,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_signature_operator_token_call_fails() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let operator_nonce = 0u64;
+
+    // generate signature with the owner keys
+    let token_call_name = String::from("freeze");
+    let freeze_account = Account::External(keys.test_pk[0]);
+    let token_call_args = rkyv_serialize(&freeze_account);
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![7u8];
+    let sig = test_keys_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check operator nonce is not incremented
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn burn_operator_token_call() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut operator_nonce = 0u64;
+
+    //
+    // test calling burn with less than a super-majority of signers doesn't work
+    //
+
+    // generate signature
+    let token_call_name = String::from("burn");
+    let burn_amount = 1000u64;
+    let token_call_args = rkyv_serialize(&burn_amount);
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![1u8, 2, 4, 7, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_NOT_MET);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check operator nonce not incremented
+    assert_eq!(
+        session
+            .query_governance::<_, u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check total-supply didn't change
+    // all keys and the governance-contract hold the initial balance at
+    // initialization
+    let initial_supply =
+        (OWNER + OPERATOR + TEST) as u64 * INITIAL_BALANCE + INITIAL_BALANCE;
+    assert_eq!(
+        session.query_token::<_, u64>("total_supply", &())?.data,
+        initial_supply,
+    );
+
+    //
+    // test calling burn with a super-majority of signers works
+    //
+
+    // generate signature
+    let token_call_name = String::from("burn");
+    let burn_amount = 1000u64;
+    let token_call_args = rkyv_serialize(&burn_amount);
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![1u8, 2, 4, 5, 7, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<_, u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check total-supply has decreased
+    assert_eq!(
+        session.query_token::<_, u64>("total_supply", &())?.data,
+        initial_supply - burn_amount,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn force_transfer_operator_token_call() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut operator_nonce = 0u64;
+
+    //
+    // test calling forced-transfer with a super-majority of signers works
+    //
+
+    // generate signature
+    let token_call_name = String::from("force_transfer");
+    let obliged_sender = Account::from(keys.test_pk[3]);
+    let receiver = Account::from(keys.test_pk[5]);
+    let value = 100u64;
+    let token_call_args = rkyv_serialize(&(obliged_sender, receiver, value));
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![1u8, 2, 4, 5, 7, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<_, u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check obliged sender funds decreased
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>("account", &obliged_sender)?
+            .data
+            .balance,
+        INITIAL_BALANCE - value,
+    );
+    // check receiver funds increased
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>("account", &receiver)?
+            .data
+            .balance,
+        INITIAL_BALANCE + value,
+    );
+
+    Ok(())
+}
+
+/*
+ * Test `set_operator_token_call`
+ */
+
+#[test]
+fn set_operator_token_call() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut operator_nonce = 0u64;
+
+    //
+    // test updating threshold of token call works
+    //
+
+    // generate signature
+    let token_call_name = String::from("block");
+    let new_threshold = 3u8;
+    let sig_msg = signature_messages::set_operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        new_threshold,
+    );
+    let signers = vec![1u8, 2, 4, 5, 7, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_operator_token_call";
+    let call_args = (token_call_name.clone(), new_threshold, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check threshold updated
+    assert_eq!(
+        session
+            .query_governance::<String, u8>(
+                "operator_signature_threshold",
+                &token_call_name
+            )?
+            .data,
+        new_threshold,
+    );
+    // check call with previous lower threshold now panics
+    let block_account = Account::External(keys.test_pk[0]);
+    let token_call_args = rkyv_serialize(&block_account);
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![4u8];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::THRESHOLD_NOT_MET);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    //
+    // test adding token call works
+    //
+
+    let token_call_name = String::from("transfer");
+    let sig_msg = signature_messages::set_operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        new_threshold,
+    );
+    let signers = vec![0u8, 3, 4, 5, 8, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_operator_token_call";
+    let call_args = (token_call_name.clone(), new_threshold, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check threshold is correct
+    assert_eq!(
+        session
+            .query_governance::<String, u8>(
+                "operator_signature_threshold",
+                &token_call_name
+            )?
+            .data,
+        new_threshold,
+    );
+
+    Ok(())
+}
+
+/*
+ * Test token calls needing owner approval fail
+ */
+
+#[test]
+fn renounce_governance_fails() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let operator_nonce = 0u64;
+
+    //
+    // test renouncing governance on token-contract fails with operator approval
+    //
+
+    // generate signature
+    let sig_msg = signature_messages::renounce_governance(operator_nonce);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = operator_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "renounce_governance";
+    let call_args = (sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check operator nonce is not incremented
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+    // check governance not updated on token-contract
+    assert_eq!(
+        session.query_token::<(), Account>("governance", &())?.data,
+        GOVERNANCE_ID.into(),
+    );
+
+    Ok(())
+}

--- a/governance/tests/owners.rs
+++ b/governance/tests/owners.rs
@@ -1,0 +1,449 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_core::abi::{ContractError, ContractId, CONTRACT_ID_BYTES};
+use dusk_core::signatures::bls::{
+    MultisigSignature, PublicKey as AccountPublicKey,
+};
+use emt_core::error;
+use emt_core::governance::signature_messages;
+use emt_core::{Account, AccountInfo, ZERO_ADDRESS};
+use emt_tests::utils::rkyv_serialize;
+
+pub mod common;
+use common::instantiate::{TestKeys, TestSession, INITIAL_BALANCE, TOKEN_ID};
+use common::{owner_signature, test_keys_signature};
+
+const OWNER: usize = 10;
+const OPERATOR: usize = 10;
+const TEST: usize = 10;
+
+#[test]
+fn set_token_contract() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut owner_nonce = 0u64;
+
+    // generate signature
+    let new_token_contract = ContractId::from_bytes([42; CONTRACT_ID_BYTES]);
+    let sig_msg = signature_messages::set_token_contract(
+        owner_nonce,
+        &new_token_contract,
+    );
+    let signers = vec![0u8, 1, 4, 5, 6, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_token_contract";
+    let call_args = (new_token_contract, sig, signers);
+    let old_token_contract = session
+        .execute_governance::<(ContractId, MultisigSignature, Vec<u8>), ContractId>(
+            &keys.test_sk[0],
+            call_name,
+            &call_args,
+        )
+        ?
+        .data;
+
+    // check that the old contract-ID is returned
+    assert_eq!(old_token_contract, TOKEN_ID);
+    // check that the token-contract on the governance-contract updated
+    assert_eq!(
+        session
+            .query_governance::<(), ContractId>("token_contract", &())?
+            .data,
+        new_token_contract,
+    );
+    // check owner nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn set_owners() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut owner_nonce = 0u64;
+
+    //
+    // test empty owner
+    //
+
+    // generate signature
+    let new_owners = Vec::new();
+    let sig_msg = signature_messages::set_owners(owner_nonce, vec![]);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_owners";
+    let call_args = (new_owners, sig, signers);
+    let contract_err = session
+        .execute_governance
+        ::<(Vec<AccountPublicKey>, MultisigSignature, Vec<u8>), ()>
+        (
+            &keys.test_sk[0],
+            call_name,
+            &call_args
+        )
+        .expect_err("Call should panic");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::EMPTY_OWNER);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check owners not updated
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("owners", &())?
+            .data,
+        keys.owners_pk
+    );
+    // check nonce is not incremented
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+
+    //
+    // test valid owner
+    //
+
+    // generate signature
+    let new_owners: Vec<AccountPublicKey> = keys.test_pk.to_vec();
+    let sig_msg = signature_messages::set_owners(owner_nonce, &new_owners);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_owners";
+    let call_args = (new_owners, sig, signers);
+    session
+        .execute_governance
+        ::<(Vec<AccountPublicKey>, MultisigSignature, Vec<u8>), ()>
+        (
+            &keys.test_sk[0],
+            call_name,
+            &call_args
+        )
+        ?;
+
+    // check updated owners
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("owners", &())?
+            .data,
+        keys.test_pk
+    );
+    // check nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+
+    //
+    // test old owner keys don't work anymore
+    //
+
+    // sign with old owner keys
+    let new_owners = vec![
+        keys.owners_pk[0],
+        keys.owners_pk[1],
+        keys.owners_pk[2],
+        keys.owners_pk[3],
+    ];
+    let sig_msg = signature_messages::set_owners(owner_nonce, &new_owners);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let old_owner_sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_owners";
+    let call_args = (new_owners.clone(), old_owner_sig, signers.clone());
+    let contract_err = session
+        .execute_governance
+        ::<(Vec<AccountPublicKey>, MultisigSignature, Vec<u8>), ()>
+        (
+            &keys.test_sk[0],
+            call_name,
+            &call_args
+        )
+        .expect_err("Call should panic");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+
+    //
+    // test new keys do work
+    //
+
+    // sign with new owner keys
+    let new_owner_sig = test_keys_signature(&keys, &sig_msg, &signers);
+    let call_args = (new_owners.clone(), new_owner_sig, signers);
+    session
+        .execute_governance
+        ::<(Vec<AccountPublicKey>, MultisigSignature, Vec<u8>), ()>
+        (&keys.test_sk[0], call_name, &call_args)
+        ?;
+
+    // check updated owners
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("owners", &())?
+            .data,
+        new_owners
+    );
+    // check nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn set_operators() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut owner_nonce = 0u64;
+
+    //
+    // test updating operator works
+    //
+
+    // generate signature
+    let new_operators: Vec<AccountPublicKey> = keys.test_pk.to_vec();
+    let sig_msg =
+        signature_messages::set_operators(owner_nonce, &new_operators);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "set_operators";
+    let call_args = (new_operators, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check updated operators
+    assert_eq!(
+        session
+            .query_governance::<(), Vec<AccountPublicKey>>("operators", &())?
+            .data,
+        keys.test_pk
+    );
+    // check owner nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+
+    //
+    // test new operators can execute operator functions
+    //
+
+    // generate signature with the new operator keys
+    let mut operator_nonce = 0u64;
+    let mint_amount = 1000;
+    let mint_receiver = Account::from(keys.test_pk[0]);
+    let token_call_name = "mint".to_string();
+    let token_call_args = rkyv_serialize(&(mint_receiver, mint_amount));
+    let sig_msg = signature_messages::operator_token_call(
+        operator_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![4u8, 5, 6, 7, 8, 9];
+    let sig = test_keys_signature(&keys, &sig_msg, &signers);
+
+    let governance_call_name = "operator_token_call";
+    let governance_call_args = (token_call_name, token_call_args, sig, signers);
+
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[1],
+        governance_call_name,
+        &governance_call_args,
+    )?;
+
+    // check updated balance for mint-receiver
+    assert_eq!(
+        session
+            .query_token::<Account, AccountInfo>("account", &mint_receiver)?
+            .data
+            .balance,
+        INITIAL_BALANCE + mint_amount,
+    );
+    // check operator nonce is incremented
+    operator_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("operator_nonce", &())?
+            .data,
+        operator_nonce,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn transfer_governance() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut owner_nonce = 0u64;
+
+    //
+    // test transferring governance on token-contract to a public key works
+    //
+
+    // generate signature
+    let new_governance = Account::External(keys.test_pk[0]);
+    let sig_msg =
+        signature_messages::transfer_governance(owner_nonce, &new_governance);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "transfer_governance";
+    let call_args = (new_governance, sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check owner nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+    // check governance updated on token-contract
+    assert_eq!(
+        session.query_token::<(), Account>("governance", &())?.data,
+        new_governance,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn renounce_governance() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let mut owner_nonce = 0u64;
+
+    //
+    // test renouncing governance on token-contract works
+    //
+
+    // generate signature
+    let sig_msg = signature_messages::renounce_governance(owner_nonce);
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "renounce_governance";
+    let call_args = (sig, signers);
+    session.execute_governance::<_, ()>(
+        &keys.test_sk[0],
+        call_name,
+        &call_args,
+    )?;
+
+    // check owner nonce is incremented
+    owner_nonce += 1;
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+    // check governance updated on token-contract
+    assert_eq!(
+        session.query_token::<(), Account>("governance", &())?.data,
+        ZERO_ADDRESS,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn executing_operator_operations_fails() -> Result<(), ContractError> {
+    let mut session = TestSession::new::<OWNER, OPERATOR, TEST>();
+    let keys: TestKeys<OWNER, OPERATOR, TEST> = TestKeys::new();
+    let owner_nonce = 0u64;
+
+    //
+    // test executing toggle-pause on token contract doesn't work
+    //
+
+    // generate signature
+    let token_call_name = String::from("toggle_pause");
+    let token_call_args = vec![];
+    let sig_msg = signature_messages::operator_token_call(
+        owner_nonce,
+        token_call_name.as_str(),
+        &token_call_args,
+    );
+    let signers = vec![0u8, 2, 5, 7, 8, 9];
+    let sig = owner_signature(&keys, &sig_msg, &signers);
+
+    // call contract
+    let call_name = "operator_token_call";
+    let call_args = (token_call_name, token_call_args, sig, signers);
+    let contract_err = session
+        .execute_governance::<_, ()>(&keys.test_sk[0], call_name, &call_args)
+        .expect_err("Call should not pass");
+
+    // check contract panic
+    if let ContractError::Panic(panic_msg) = contract_err {
+        assert_eq!(panic_msg, error::INVALID_SIGNATURE);
+    } else {
+        panic!("Expected panic, got error: {contract_err}",);
+    }
+    // check owner nonce is not incremented
+    assert_eq!(
+        session
+            .query_governance::<(), u64>("owner_nonce", &())?
+            .data,
+        owner_nonce,
+    );
+    // check token-contract is not paused
+    assert_eq!(
+        session.query_token::<(), bool>("is_paused", &())?.data,
+        false,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the basic functionality of the governance contract to sign off calls to the token contract by a multisig.

The ability store and aggregate signatures on chain, triggering the call to the token-contract when the required threshold is met, will be added in #47.

The governance contract divides access control into two roles:
- owner are allowed to change the governance
- operator are allowed to do everything else that needs governance approval in the token-contract