### PR TITLE
Add test for double initialization

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -413,19 +413,20 @@ impl TokenState {
 
         obliged_sender_account.balance -= value;
 
-        let to = *transfer.receiver();
-        let to_account = self.accounts.entry(to).or_insert(AccountInfo::EMPTY);
+        let receiver = *transfer.receiver();
+        let receiver_account =
+            self.accounts.entry(receiver).or_insert(AccountInfo::EMPTY);
 
         // this can never overflow as value + balance is never higher than total
         // supply
-        to_account.balance += value;
+        receiver_account.balance += value;
 
         abi::emit(
             TransferEvent::FORCE_TRANSFER_TOPIC,
             TransferEvent {
                 sender: obliged_sender,
                 spender: None,
-                receiver: to,
+                receiver,
                 value,
             },
         );
@@ -516,21 +517,22 @@ impl TokenState {
             )
         };
 
-        let to = *transfer.receiver();
-        let to_account = self.accounts.entry(to).or_insert(AccountInfo::EMPTY);
+        let receiver = *transfer.receiver();
+        let receiver_account =
+            self.accounts.entry(receiver).or_insert(AccountInfo::EMPTY);
 
-        assert!(!to_account.is_blocked(), "{}", BLOCKED);
+        assert!(!receiver_account.is_blocked(), "{}", BLOCKED);
 
         // this can never overflow as value + balance is never higher than total
         // supply
-        to_account.balance += value;
+        receiver_account.balance += value;
 
         abi::emit(
             TransferEvent::TRANSFER_TOPIC,
             TransferEvent {
                 sender,
                 spender: None,
-                receiver: to,
+                receiver,
                 value,
             },
         );
@@ -538,7 +540,7 @@ impl TokenState {
         // if the transfer is to a contract, the acceptance function of said
         // contract is called. if it fails (panic or OoG) the transfer
         // also fails.
-        if let Account::Contract(contract) = to {
+        if let Account::Contract(contract) = receiver {
             if let Err(err) = abi::call::<_, ()>(
                 contract,
                 "token_received",
@@ -613,20 +615,21 @@ impl TokenState {
         *allowance -= value;
         owner_account.balance -= value;
 
-        let to = *transfer.receiver();
-        let to_account = self.accounts.entry(to).or_insert(AccountInfo::EMPTY);
-        assert!(!to_account.is_blocked(), "{}", BLOCKED);
+        let receiver = *transfer.receiver();
+        let receiver_account =
+            self.accounts.entry(receiver).or_insert(AccountInfo::EMPTY);
+        assert!(!receiver_account.is_blocked(), "{}", BLOCKED);
 
         // this can never overflow as value + balance is never higher than total
         // supply
-        to_account.balance += value;
+        receiver_account.balance += value;
 
         abi::emit(
             TransferEvent::TRANSFER_TOPIC,
             TransferEvent {
                 sender: owner,
                 spender: Some(spender),
-                receiver: to,
+                receiver,
                 value,
             },
         );
@@ -634,7 +637,7 @@ impl TokenState {
         // if the transfer is to a contract, the acceptance function of said
         // contract is called. if it fails (panic or OoG) the transfer
         // also fails.
-        if let Account::Contract(contract) = to {
+        if let Account::Contract(contract) = receiver {
             if let Err(err) = abi::call::<_, ()>(
                 contract,
                 "token_received",

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -211,6 +211,46 @@ fn empty_account() {
     );
 }
 
+// test that the token contract can not be initialized when it already carries
+// data.
+#[test]
+fn double_init() {
+    const INSERT_VALUE: u64 = INITIAL_BALANCE + 42;
+
+    let mut session = ContractSession::new();
+
+    // generate new keys
+    let mut rng = StdRng::seed_from_u64(0xBEEF);
+    let sk = SecretKey::random(&mut rng);
+    let pk = PublicKey::from(&sk);
+
+    let receipt =
+        session.call_token::<_, ()>("init", &(vec![(pk, INSERT_VALUE)], pk));
+
+    // attempt to insert new keys that holds token into the state by calling
+    // `init` function after contract initialization
+    match receipt.err() {
+        Some(VMError::InitalizationError(panic_msg)) => {
+            assert_eq!(panic_msg, "init call not allowed");
+        }
+        _ => {
+            panic!("Expected a panic error");
+        }
+    }
+
+    assert_eq!(
+        session.account(pk).balance,
+        0,
+        "The new account should have 0 balance"
+    );
+
+    assert_ne!(
+        session.owner().expect("Querying owner should succeed").data,
+        Account::External(pk),
+        "The token-contract owner shouldn't have changed"
+    );
+}
+
 #[test]
 fn transfer() {
     const TRANSFERRED_AMOUNT: u64 = INITIAL_BALANCE - 1;


### PR DESCRIPTION
Changes in this PR:
- Add tests that check that double initialization is not possible
- Rename same internal variables `to` -> `receiver` for consistency