### PR TITLE
Rename `ttoken..` -> `emt..`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-ttoken-types = { path = "./types", version = "=0.1.0" }
-ttoken-tests = { path = "./tests/" }
+emt-types = { path = "./types", version = "=0.1.0" }
+emt-tests = { path = "./tests/" }
 
 dusk-bytes = "0.1"
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "ttoken-contract"
+name = "emt-contract"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ttoken-types = { workspace = true }
+emt-types = { workspace = true }
 dusk-core = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 dusk-core = { workspace = true, features = ["abi-dlmalloc"] }
 
 [dev-dependencies]
-ttoken-tests = { workspace = true }
+emt-tests = { workspace = true }
 dusk-vm = { workspace = true }
 rkyv = { workspace = true }
 bytecheck = { workspace = true }

--- a/contract/Makefile
+++ b/contract/Makefile
@@ -1,5 +1,5 @@
-TOKEN_WASM:="../target/wasm64-unknown-unknown/release/ttoken_contract.wasm"
-TEST_HOLDER_WASM:="../target/wasm64-unknown-unknown/release/ttoken_holder_contract.wasm"
+TOKEN_WASM:="../target/wasm64-unknown-unknown/release/emt_contract.wasm"
+TEST_HOLDER_WASM:="../target/wasm64-unknown-unknown/release/emt_holder_contract.wasm"
 
 all: ## Build the token contract
 	@cargo build --release

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -18,19 +18,19 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use dusk_core::abi;
-use ttoken_types::admin_management::events::PauseToggled;
-use ttoken_types::admin_management::PAUSED_MESSAGE;
-use ttoken_types::governance::arguments::TransferGovernance;
-use ttoken_types::governance::events::{
+use emt_types::admin_management::events::PauseToggled;
+use emt_types::admin_management::PAUSED_MESSAGE;
+use emt_types::governance::arguments::TransferGovernance;
+use emt_types::governance::events::{
     GovernanceRenouncedEvent, GovernanceTransferredEvent,
 };
-use ttoken_types::governance::{GOVERNANCE_NOT_FOUND, UNAUTHORIZED_ACCOUNT};
-use ttoken_types::sanctions::arguments::Sanction;
-use ttoken_types::sanctions::events::AccountStatusEvent;
-use ttoken_types::sanctions::{BLOCKED, FROZEN};
-use ttoken_types::supply_management::events::{BURN_TOPIC, MINT_TOPIC};
-use ttoken_types::supply_management::SUPPLY_OVERFLOW;
-use ttoken_types::{
+use emt_types::governance::{GOVERNANCE_NOT_FOUND, UNAUTHORIZED_ACCOUNT};
+use emt_types::sanctions::arguments::Sanction;
+use emt_types::sanctions::events::AccountStatusEvent;
+use emt_types::sanctions::{BLOCKED, FROZEN};
+use emt_types::supply_management::events::{BURN_TOPIC, MINT_TOPIC};
+use emt_types::supply_management::SUPPLY_OVERFLOW;
+use emt_types::{
     Account, AccountInfo, Allowance, Approve, ApproveEvent, Transfer,
     TransferEvent, TransferFrom, TransferInfo, ACCOUNT_NOT_FOUND,
     BALANCE_TOO_LOW, SHIELDED_NOT_SUPPORTED, ZERO_ADDRESS,

--- a/contract/tests/instantiate.rs
+++ b/contract/tests/instantiate.rs
@@ -27,15 +27,15 @@ use rkyv::{Archive, Deserialize, Infallible, Serialize};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-use ttoken_types::*;
+use emt_types::*;
 
-use ttoken_tests::network::NetworkSession;
+use emt_tests::network::NetworkSession;
 
 const TOKEN_BYTECODE: &[u8] = include_bytes!(
-    "../../target/wasm64-unknown-unknown/release/ttoken_contract.wasm"
+    "../../target/wasm64-unknown-unknown/release/emt_contract.wasm"
 );
 const HOLDER_BYTECODE: &[u8] = include_bytes!(
-    "../../target/wasm64-unknown-unknown/release/ttoken_holder_contract.wasm"
+    "../../target/wasm64-unknown-unknown/release/emt_holder_contract.wasm"
 );
 
 const DEPLOYER: [u8; 64] = [0u8; 64];

--- a/contract/tests/token.rs
+++ b/contract/tests/token.rs
@@ -14,13 +14,13 @@ use dusk_core::transfer::MoonlightTransactionEvent;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-use ttoken_types::admin_management::PAUSED_MESSAGE;
-use ttoken_types::governance::arguments::TransferGovernance;
-use ttoken_types::governance::UNAUTHORIZED_ACCOUNT;
-use ttoken_types::sanctions::arguments::Sanction;
-use ttoken_types::sanctions::{BLOCKED, FROZEN};
-use ttoken_types::supply_management::SUPPLY_OVERFLOW;
-use ttoken_types::*;
+use emt_types::admin_management::PAUSED_MESSAGE;
+use emt_types::governance::arguments::TransferGovernance;
+use emt_types::governance::UNAUTHORIZED_ACCOUNT;
+use emt_types::sanctions::arguments::Sanction;
+use emt_types::sanctions::{BLOCKED, FROZEN};
+use emt_types::supply_management::SUPPLY_OVERFLOW;
+use emt_types::*;
 
 pub mod instantiate;
 use instantiate::{

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ttoken-tests"
+name = "emt-tests"
 version.workspace = true
 edition.workspace = true
 
 publish = false
 
 [dependencies]
-ttoken-types = { workspace = true }
+emt-types = { workspace = true }
 
 dusk-core = { workspace = true }
 dusk-vm = { workspace = true }

--- a/tests/holder/Cargo.toml
+++ b/tests/holder/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "ttoken-holder-contract"
+name = "emt-holder-contract"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ttoken-types = { workspace = true }
+emt-types = { workspace = true }
 
 dusk-core = { workspace = true, features = ["abi-dlmalloc"] }
 

--- a/tests/holder/src/lib.rs
+++ b/tests/holder/src/lib.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use dusk_core::abi::{self, ContractId};
 
-use ttoken_types::*;
+use emt_types::*;
 
 // The contract ID of the token contract
 const TOKEN_ID: ContractId = ContractId::from_bytes([1; 32]);

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ttoken-types"
+name = "emt-types"
 version.workspace = true
 edition.workspace = true
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Types used to inteact with the `ttoken-contract`.
+//! Types used to inteact with the `emt-contract`.
 
 #![no_std]
 #![deny(missing_docs)]


### PR DESCRIPTION
Rename all occurances of `ttoken` to `emt`.
When the contract is used for implementing a specific electronic money token, the `emt` will be replaced by the token name.