### PR TITLE
token: add events to init & remove GovernanceRenouncedEvent

### DIFF
--- a/core/src/governance.rs
+++ b/core/src/governance.rs
@@ -71,8 +71,11 @@ pub mod events {
     }
 
     impl GovernanceTransferredEvent {
-        /// Event Topic
-        pub const TOPIC: &'static str = "governance_transferred";
+        /// Event Topic for transferring the governance.
+        pub const GOVERNANCE_TRANSFERRED: &'static str =
+            "governance_transferred";
+        /// Event Topic for renouncing the governance.
+        pub const GOVERNANCE_RENOUNCED: &'static str = "governance_renounced";
     }
 
     /// Event emitted when the governance of a contract is accepted in a two
@@ -91,21 +94,5 @@ pub mod events {
     impl GovernanceAcceptedEvent {
         /// Event Topic
         pub const TOPIC: &'static str = "governance_accepted";
-    }
-
-    /// Event emitted when the governance of a contract is renounced i.e., no
-    /// governance exists anymore.
-    #[derive(
-        Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize,
-    )]
-    #[archive_attr(derive(CheckBytes))]
-    pub struct GovernanceRenouncedEvent {
-        /// The previous governance of the contract.
-        pub previous_governance: Account,
-    }
-
-    impl GovernanceRenouncedEvent {
-        /// Event Topic
-        pub const TOPIC: &'static str = "governance_renounced";
     }
 }

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -50,10 +50,20 @@ struct TokenState {
 impl TokenState {
     fn init(&mut self, accounts: Vec<(Account, u64)>, governance: Account) {
         for (account, balance) in accounts {
-            let account =
+            let account_entry =
                 self.accounts.entry(account).or_insert(AccountInfo::EMPTY);
-            account.balance += balance;
+            account_entry.balance += balance;
             self.supply += balance;
+
+            abi::emit(
+                MINT_TOPIC,
+                TransferEvent {
+                    sender: ZERO_ADDRESS,
+                    spender: None,
+                    receiver: account,
+                    value: balance,
+                },
+            );
         }
 
         // Set the governance
@@ -63,6 +73,14 @@ impl TokenState {
         self.accounts
             .entry(self.governance)
             .or_insert(AccountInfo::EMPTY);
+
+        abi::emit(
+            GovernanceTransferredEvent::TOPIC,
+            GovernanceTransferredEvent {
+                previous_governance: ZERO_ADDRESS,
+                new_governance: governance,
+            },
+        );
     }
 }
 

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -21,9 +21,7 @@ use dusk_core::abi;
 use emt_core::admin_management::events::PauseToggled;
 use emt_core::admin_management::PAUSED_MESSAGE;
 use emt_core::governance::arguments::TransferGovernance;
-use emt_core::governance::events::{
-    GovernanceRenouncedEvent, GovernanceTransferredEvent,
-};
+use emt_core::governance::events::GovernanceTransferredEvent;
 use emt_core::governance::{GOVERNANCE_NOT_FOUND, UNAUTHORIZED_ACCOUNT};
 use emt_core::sanctions::arguments::Sanction;
 use emt_core::sanctions::events::AccountStatusEvent;
@@ -75,7 +73,7 @@ impl TokenState {
             .or_insert(AccountInfo::EMPTY);
 
         abi::emit(
-            GovernanceTransferredEvent::TOPIC,
+            GovernanceTransferredEvent::GOVERNANCE_TRANSFERRED,
             GovernanceTransferredEvent {
                 previous_governance: ZERO_ADDRESS,
                 new_governance: governance,
@@ -121,7 +119,7 @@ impl TokenState {
             .or_insert(AccountInfo::EMPTY);
 
         abi::emit(
-            GovernanceTransferredEvent::TOPIC,
+            GovernanceTransferredEvent::GOVERNANCE_TRANSFERRED,
             GovernanceTransferredEvent {
                 previous_governance,
                 new_governance,
@@ -136,9 +134,10 @@ impl TokenState {
         self.governance = ZERO_ADDRESS;
 
         abi::emit(
-            GovernanceRenouncedEvent::TOPIC,
-            GovernanceRenouncedEvent {
+            GovernanceTransferredEvent::GOVERNANCE_RENOUNCED,
+            GovernanceTransferredEvent {
                 previous_governance,
+                new_governance: ZERO_ADDRESS,
             },
         );
     }


### PR DESCRIPTION
This PR adds emitting events during state initialization. Resolves #35 

Additionally, it simplifies the Governance events by removing `GovernanceRenouncedEvent`. Now, it follows a similar approach as "mint" and "burn" events. `renounce_governance` now emits a GovernanceTransferredEvent when called, with the governance being transferred to the ZERO_ADDRESS.