### PR TITLE
token: introduce transfer_and_call

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,4 +38,4 @@ pub use token::account::{
     Account, AccountInfo, ACCOUNT_NOT_FOUND, BALANCE_TOO_LOW, INVALID_CALLER,
     SHIELDED_NOT_SUPPORTED,
 };
-pub use token::{ApproveEvent, TransferEvent, TransferInfo, ZERO_ADDRESS};
+pub use token::{ApproveEvent, TransferEvent, ZERO_ADDRESS};

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -59,15 +59,3 @@ impl ApproveEvent {
     /// Event topic used when a spender is approved.
     pub const APPROVE_TOPIC: &'static str = "approve";
 }
-
-/// Used to inform a contract of the source of funds they're receiving.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize,
-)]
-#[archive_attr(derive(CheckBytes))]
-pub struct TransferInfo {
-    /// The originating account of the funds transferred to the contract.
-    pub sender: Account,
-    /// The number of tokens transferred.
-    pub value: u64,
-}

--- a/tests/holder/src/lib.rs
+++ b/tests/holder/src/lib.rs
@@ -88,6 +88,10 @@ impl TokenState {
             }
         }
     }
+
+    fn tracked_balance(&self) -> u64 {
+        self.balance
+    }
 }
 
 #[no_mangle]
@@ -107,4 +111,9 @@ unsafe fn token_send(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe fn token_received(arg_len: u32) -> u32 {
     abi::wrap_call(arg_len, |arg| STATE.token_received(arg))
+}
+
+#[no_mangle]
+unsafe fn tracked_balance(arg_len: u32) -> u32 {
+    abi::wrap_call(arg_len, |(): ()| STATE.tracked_balance())
 }

--- a/token/tests/token.rs
+++ b/token/tests/token.rs
@@ -9,6 +9,7 @@ use dusk_core::abi::{ContractId, CONTRACT_ID_BYTES};
 use dusk_core::signatures::bls::{
     PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
 };
+use dusk_core::transfer::data::ContractCall;
 use dusk_core::transfer::MoonlightTransactionEvent;
 
 use rand::rngs::StdRng;
@@ -139,7 +140,7 @@ fn transfer_to_contract() {
     assert_eq!(
         session.account(HOLDER_ID).balance,
         INITIAL_HOLDER_BALANCE,
-        "The contract to transfer to should have its initial balance"
+        "The receiver contract should have its initial balance"
     );
 
     let contract_account = Account::from(HOLDER_ID);
@@ -162,6 +163,65 @@ fn transfer_to_contract() {
         session.account(HOLDER_ID).balance,
         INITIAL_HOLDER_BALANCE + TRANSFERRED_AMOUNT,
         "The contract transferred to should have the transferred amount added"
+    );
+
+    assert_eq!(
+        session.holder_tracked_balance(),
+        INITIAL_HOLDER_BALANCE,
+        "The contract should have no knowledge of the transfer"
+    );
+}
+
+/// Test a token transfer and call from the deploy account to the test contract
+/// account.
+#[test]
+fn transfer_and_call_to_contract() {
+    const TRANSFERRED_AMOUNT: u64 = INITIAL_BALANCE - 1;
+
+    let mut session = TestSession::new();
+    let account_1 = Account::from(*TestSession::PK_1);
+    let contract_call = ContractCall::new(
+        HOLDER_ID,
+        "token_received",
+        &(account_1, TRANSFERRED_AMOUNT),
+    )
+    .expect("Creating contract call should succeed");
+
+    assert_eq!(
+        session.account(*TestSession::PK_1).balance,
+        INITIAL_BALANCE,
+        "The deployed account should have the initial balance"
+    );
+    assert_eq!(
+        session.account(HOLDER_ID).balance,
+        INITIAL_HOLDER_BALANCE,
+        "The receiver contract should have its initial balance"
+    );
+
+    session
+        .call_token::<_, ()>(
+            &*TestSession::SK_1,
+            "transfer_and_call",
+            &(TRANSFERRED_AMOUNT, contract_call),
+        )
+        .expect("Call should pass");
+
+    assert_eq!(
+        session.account(*TestSession::PK_1).balance,
+        INITIAL_BALANCE - TRANSFERRED_AMOUNT,
+        "The deployed account should have the transferred amount subtracted"
+    );
+
+    assert_eq!(
+        session.account(HOLDER_ID).balance,
+        INITIAL_HOLDER_BALANCE + TRANSFERRED_AMOUNT,
+        "The contract transferred to should have the transferred amount added"
+    );
+
+    assert_eq!(
+        session.holder_tracked_balance(),
+        INITIAL_HOLDER_BALANCE + TRANSFERRED_AMOUNT,
+        "The contract should have knowledge of the transfer"
     );
 }
 
@@ -536,13 +596,7 @@ fn test_pause() {
         .call_token::<_, ()>(&*TestSession::SK_0, "toggle_pause", &())
         .expect("Call should pass");
 
-    assert_eq!(
-        session
-            .call_getter::<bool>("is_paused")
-            .expect("call to pass")
-            .data,
-        true
-    );
+    assert_eq!(session.is_paused(), true);
 
     let receipt = session.call_token::<_, ()>(
         &*TestSession::SK_1,
@@ -572,13 +626,7 @@ fn test_pause() {
         .call_token::<_, ()>(&*TestSession::SK_0, "toggle_pause", &())
         .expect("Call should pass");
 
-    assert_eq!(
-        session
-            .call_getter::<bool>("is_paused")
-            .expect("call to pass")
-            .data,
-        false
-    );
+    assert_eq!(session.is_paused(), false);
 
     session
         .call_token::<_, ()>(


### PR DESCRIPTION
Resolves #39 by choosing the first option outlined in the issue. Additionally, the transfer of value can only be to the contract that is called.

The PR removes the `TransferInfo` struct and also the call in the normal transfer & transfer_from function in favor of introducing a `transfer_and_call` function that takes the more generic `contract_call` argument. The transfer_from function no longer calls a contract function, and this is desired to create ERC20 compatibility in terms of behavior.