### PR TITLE
token: add balance_of

### DIFF
--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -357,6 +357,13 @@ impl TokenState {
             .unwrap_or(AccountInfo::EMPTY)
     }
 
+    fn balance_of(&self, account: Account) -> u64 {
+        match self.accounts.get(&account) {
+            Some(account_info) => account_info.balance,
+            None => 0,
+        }
+    }
+
     #[allow(clippy::large_types_passed_by_value)]
     fn allowance(&self, owner: Account, spender: Account) -> u64 {
         match self.allowances.get(&owner) {
@@ -542,6 +549,11 @@ unsafe extern "C" fn total_supply(arg_len: u32) -> u32 {
 #[no_mangle]
 unsafe extern "C" fn account(arg_len: u32) -> u32 {
     abi::wrap_call(arg_len, |arg| STATE.account(arg))
+}
+
+#[no_mangle]
+unsafe extern "C" fn balance_of(arg_len: u32) -> u32 {
+    abi::wrap_call(arg_len, |account| STATE.balance_of(account))
 }
 
 #[no_mangle]

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -89,6 +89,10 @@ static mut STATE: TokenState = TokenState {
 
 /// Access control implementation.
 impl TokenState {
+    fn governance(&self) -> Account {
+        self.governance
+    }
+
     fn governance_info_mut(&mut self) -> &mut AccountInfo {
         self.accounts
             .get_mut(&self.governance)
@@ -596,7 +600,7 @@ unsafe extern "C" fn renounce_governance(arg_len: u32) -> u32 {
 
 #[no_mangle]
 unsafe extern "C" fn governance(arg_len: u32) -> u32 {
-    abi::wrap_call(arg_len, |(): ()| STATE.governance)
+    abi::wrap_call(arg_len, |(): ()| STATE.governance())
 }
 
 /*

--- a/token/tests/instantiate.rs
+++ b/token/tests/instantiate.rs
@@ -191,6 +191,13 @@ impl TestSession {
             .data
     }
 
+    pub fn balance_of(&mut self, account: impl Into<Account>) -> u64 {
+        self.session
+            .direct_call(TOKEN_ID, "balance_of", &account.into())
+            .expect("call to pass")
+            .data
+    }
+
     pub fn governance(&mut self) -> Account {
         self.call_getter("governance").expect("call to pass").data
     }

--- a/token/tests/token.rs
+++ b/token/tests/token.rs
@@ -326,6 +326,11 @@ fn transfer_from() {
         "The account transferred to should have the transferred amount"
     );
     assert_eq!(
+        session.balance_of(spender_account),
+        TRANSFERRED_AMOUNT,
+        "The account transferred to should have the transferred amount"
+    );
+    assert_eq!(
         session.allowance(*TestSession::PK_1, spender_account),
         APPROVED_AMOUNT - TRANSFERRED_AMOUNT,
         "The account should have the transferred amount subtracted from its allowance"


### PR DESCRIPTION
Resolves #51

This PR also added a getter function for the governance. The reason for this is consistency with the other functions & for documentation purposes. This allows to consistently show the "real" function signatures of available functions and not just the wrapped call versions, which all have the opaque signature `unsafe extern "C" fn fn_name(arg_len: u32) -> u32`. 